### PR TITLE
Make star-randsrv build reproducibly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ $(image_tar): Dockerfile $(RUST_DEPS) $(NITRIDING_DEPS) nitriding/cmd/Makefile
 		--reproducible \
 		--no-push \
 		--tarPath $(image_tar) \
-		--destination $(image_tag)
+		--destination $(image_tag) \
+		--custom-platform linux/amd64
 
 run: $(image_eif)
 	$(eval ENCLAVE_ID=$(shell nitro-cli describe-enclaves | jq -r '.[0].EnclaveID'))


### PR DESCRIPTION
This commit makes two changes:

1. Invoke kaniko with the flag '--custom-platform linux/amd64'.  This is necessary when building star-randsrv on non-Linux, non-amd64 platforms like macOS.

2. Use an intermediate build layer to add start.sh.  If we don't do this, we may end up with a build layer that contains inconsistent file permissions from the host operating system.

With the above two changes, it's now possible to arrive at identical image IDs, even when building star-randsrv on Linux (amd64) and macOS (arm64).