### PR TITLE
Dockerfile: specify golang-1.20.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start by building the nitriding proxy daemon.
-FROM public.ecr.aws/docker/library/golang:1.20 as go-builder
+FROM public.ecr.aws/docker/library/golang:1.20.3 as go-builder
 
 WORKDIR /src/
 COPY . .


### PR DESCRIPTION
Improve build reproducibility by specifying a specific point release of the go builder image, like we do for the alpine runtime images.