### PR TITLE
Clean up docker and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ tower = "0.4.13"
 
 [profile.release]
 lto = "thin"
+panic = "abort"
 strip = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "star-randsrv"
 version = "0.2.0"
 authors = ["Ralph Giles <rgiles@brave.com>"]
 description = "STAR randomness webservice"
+license = "MPL-2.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,8 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 hyper = "0.14.26"
 rand_core = { version = "0.5.1", features = ["getrandom"] }
 tower = "0.4.13"
+
+[profile.release]
+lto = "thin"
+strip = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 STAR Randomness Server
 ======================
 
-This repository implements a service that serves as a front end to the
-randomness server that's proposed in the paper [STAR: Distributed Secret Sharing
+This repository implements the randomness server that's proposed
+in the paper [STAR: Distributed Secret Sharing
 for Private Threshold Aggregation Reporting](https://arxiv.org/abs/2109.10074).
-The actual randomness server implementation (written in Rust) can be found in
-the [sta-rs](https://github.com/brave/sta-rs) repository; this repository merely
-implements a Go wrapper that can be run inside an AWS Nitro Enclave.
+The actual oblivious pseudorandom function implementation can be found
+in the [sta-rs](https://github.com/brave/sta-rs) repository.
+This repository implements webservice wrapper to make evaluation available
+over the network.
+
+It also includes a reproducible container build that can be run inside an
+AWS Nitro Enclave, providing remote attestation of the implementation and
+additional security for the private key.
 
 Installation
 ------------
@@ -17,16 +22,16 @@ To test, lint, and build the randomness server, simply run:
 make
 ```
 
-To build a reproducible Docker image of the randomness server, run:
-
-```
-make docker
-```
-
 To execute just the randomness webapp with logging, run:
 
 ```
 RUST_LOG=tower_http=trace,star_randsrv=debug cargo run
+```
+
+To build a reproducible container image of the randomness server, run:
+
+```
+make image
 ```
 
 Input


### PR DESCRIPTION
Minor README update to reflect that we're using nitriding v2.

Change the release build to fail faster:

- Build with `panic=abort` so we exit and can be restarted
- Also reduces executable size by about 15%
- strip+lto to make the star-randsrv static exe half the size

Tune `Dockerfile` to speed up container builds:

- don't copy irrelevant data into the docker build context
- don't download the entire rust crate index when building