### PR TITLE
Switch nitriding url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "nitriding"]
-	path = nitriding
-	url = https://github.com/brave/nitriding-daemon.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nitriding"]
 	path = nitriding
-	url = https://github.com/brave/nitriding.git
+	url = https://github.com/brave/nitriding-daemon.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start by building the nitriding proxy daemon.
-FROM public.ecr.aws/docker/library/golang:1.20.3 as go-builder
+FROM public.ecr.aws/docker/library/golang:1.20.3-alpine as go-builder
 
 RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon/cmd@v1.0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 # Start by building the nitriding proxy daemon.
 FROM public.ecr.aws/docker/library/golang:1.20.3 as go-builder
 
-WORKDIR /src/
-COPY nitriding .
-RUN make -C cmd nitriding
+RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon/cmd@v1.0.1
 
 # Build the web server application itself.
 # Use the -alpine variant so it will run in a alpine-based container.
@@ -28,7 +26,7 @@ RUN chmod 755 /start.sh
 # Copy from the builder imagse to keep the final image reproducible and small,
 # and to improve reproducibilty of the build.
 FROM public.ecr.aws/docker/library/alpine:3.17.3
-COPY --from=go-builder /src/cmd/nitriding /usr/local/bin/
+COPY --from=go-builder /go/bin/cmd /usr/local/bin/nitriding
 COPY --from=rust-builder /src/target/release/star-randsrv /usr/local/bin/
 COPY --from=file-builder /start.sh /usr/local/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ image_tar := $(prog)-$(version)-kaniko.tar
 image_eif := $(image_tar:%.tar=%.eif)
 
 RUST_DEPS := $(wildcard Cargo.* src/*.rs)
-NITRIDING_DEPS := $(wildcard nitriding/*.go) $(wildcard nitriding/cmd/main.go)
 
 # RUST_DEPS is approximate; always invoke cargo to update $(prog).
 .PHONY: all test lint clean eif image target/release/$(prog)
@@ -27,10 +26,6 @@ clean:
 	$(RM) $(image_tar)
 	$(RM) $(image_eif)
 
-# Check out the nitriding submodule if it hasn't been already
-nitriding/cmd/Makefile:
-	git submodule update --init
-
 eif: $(image_eif)
 
 $(image_eif): $(image_tar)
@@ -39,7 +34,7 @@ $(image_eif): $(image_tar)
 
 image: $(image_tar)
 
-$(image_tar): Dockerfile $(RUST_DEPS) $(NITRIDING_DEPS) nitriding/cmd/Makefile
+$(image_tar): Dockerfile $(RUST_DEPS)
 	docker run -v $$PWD:/workspace gcr.io/kaniko-project/executor:v1.9.2 \
 		--context dir:///workspace/ \
 		--reproducible \


### PR DESCRIPTION
To fix compatibility with go tooling, the `v2` nitriding implementation where it acts as a proxy moved to a separate repository. Point our build at the lastest release of that which has some throughput optimizations.