### PR TITLE
Downgrade yanked tracing 0.1.38 to 0.1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,10 +1139,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.40"
 time = { version = "0.3.20", features = ["formatting"] }
 tokio = { version = "1.28.0", features = ["full"] }
 tower-http = { version = "0.4.0", features = ["trace"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The current release of the tracing crate was yanked for an unintended API change. https://github.com/tokio-rs/tracing/issues/2578

Revert to the next-latest release to address the audit warning.