### PR TITLE
Implement --epoch-base-time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ppoprf = { git = "https://github.com/brave/sta-rs", rev = "1937393e9d76c5333af47
 serde = "1.0.163"
 serde_json = "1.0.96"
 thiserror = "1.0.40"
-time = { version = "0.3.21", features = ["formatting"] }
+time = { version = "0.3.21", features = ["formatting", "parsing"] }
 tokio = { version = "1.28.2", features = ["full"] }
 tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = "0.1.37"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@
 use axum::{routing::get, routing::post, Router};
 use clap::Parser;
 use std::sync::{Arc, RwLock};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 use tracing::{debug, info};
 
 mod handler;
@@ -35,8 +37,14 @@ pub struct Config {
     /// Optional absolute time at which to anchor the first epoch
     /// This can be used to align the epoch sequence across different
     /// invocations.
-    #[arg(long, value_name = "RFC 3339 timestamp")]
-    epoch_base_time: Option<String>,
+    #[arg(long, value_name = "RFC 3339 timestamp", value_parser = parse_timestamp)]
+    epoch_base_time: Option<OffsetDateTime>,
+}
+
+/// Parse a timestamp given as a config option
+fn parse_timestamp(stamp: &str) -> Result<OffsetDateTime, &'static str> {
+    OffsetDateTime::parse(stamp, &Rfc3339)
+        .map_err(|_| "Try something like '2023-05-15T04:30:00Z'.")
 }
 
 /// Initialize an axum::Router for our web service

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,10 @@ pub struct Config {
     #[arg(long, default_value_t = 255)]
     last_epoch: u8,
     /// Optional absolute time at which to anchor the first epoch
+    /// This can be used to align the epoch sequence across different
+    /// invocations.
     #[arg(long, value_name = "RFC 3339 timestamp")]
-    epoch_basetime: Option<String>,
+    epoch_base_time: Option<String>,
 }
 
 /// Initialize an axum::Router for our web service

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,8 @@
 use axum::{routing::get, routing::post, Router};
 use clap::Parser;
 use std::sync::{Arc, RwLock};
-use tracing::{debug, info};
+use time::format_description::well_known::Rfc3339;
+use tracing::{debug, info, warn};
 
 mod handler;
 mod state;
@@ -20,6 +21,9 @@ const MAX_POINTS: usize = 1024;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Config {
+    /// Host and port to listen for http connections
+    #[arg(long, default_value = "127.0.0.1:8080")]
+    listen: String,
     /// Duration of each randomness epoch
     #[arg(long, default_value_t = 5)]
     epoch_seconds: u32,
@@ -29,9 +33,9 @@ pub struct Config {
     /// Last epoch tag to make available
     #[arg(long, default_value_t = 255)]
     last_epoch: u8,
-    /// Host and port to listen for http connections
-    #[arg(long, default_value = "127.0.0.1:8080")]
-    listen: String,
+    /// Optional absolute time at which to anchor the first epoch
+    #[arg(long, value_name = "RFC 3339 timestamp")]
+    epoch_basetime: Option<String>,
 }
 
 /// Initialize an axum::Router for our web service
@@ -60,6 +64,17 @@ async fn main() {
     let config = Config::parse();
     debug!(?config, "config parsed");
     let addr = config.listen.parse().unwrap();
+    let mut basetime = None;
+    if let Some(stamp) = &config.epoch_basetime {
+        basetime = match time::OffsetDateTime::parse(stamp, &Rfc3339) {
+            Ok(timestamp) => Some(timestamp),
+            Err(e) => {
+                warn!("Couldn't parse epoch-basetime argument: {e}");
+                None
+            }
+        }
+    }
+    debug!(?basetime, "parsed");
 
     // Oblivious function state
     info!("initializing OPRF state...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,7 @@
 use axum::{routing::get, routing::post, Router};
 use clap::Parser;
 use std::sync::{Arc, RwLock};
-use time::format_description::well_known::Rfc3339;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 mod handler;
 mod state;
@@ -64,17 +63,6 @@ async fn main() {
     let config = Config::parse();
     debug!(?config, "config parsed");
     let addr = config.listen.parse().unwrap();
-    let mut basetime = None;
-    if let Some(stamp) = &config.epoch_basetime {
-        basetime = match time::OffsetDateTime::parse(stamp, &Rfc3339) {
-            Ok(timestamp) => Some(timestamp),
-            Err(e) => {
-                warn!("Couldn't parse epoch-basetime argument: {e}");
-                None
-            }
-        }
-    }
-    debug!(?basetime, "parsed");
 
     // Oblivious function state
     info!("initializing OPRF state...");

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,7 +53,7 @@ pub async fn epoch_loop(state: OPRFState, config: &Config) {
     // otherwise use start_time.
     let base_time = config.epoch_base_time.unwrap_or(start_time);
     info!(
-        "epoch base time {}",
+        "epoch base time = {}",
         base_time
             .format(&Rfc3339)
             .expect("well-known timestamp format should always succeed")

--- a/src/state.rs
+++ b/src/state.rs
@@ -105,7 +105,7 @@ pub async fn epoch_loop(state: OPRFState, config: &Config) {
         // Truncate to the nearest second.
         let timestamp = next_rotation
             .replace_millisecond(0)
-            .expect("should be able to round to a fixed ms")
+            .expect("should be able to truncate to a fixed ms")
             .format(&Rfc3339)
             .expect("well-known timestamp format should always succeed");
         {

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,11 +49,15 @@ pub async fn epoch_loop(state: OPRFState, config: &Config) {
     info!("rotating epoch every {} seconds", interval.as_secs());
 
     let start_time = time::OffsetDateTime::now_utc();
-    // Parse the epoch base time if given, otherwise use start_time.
-    let base_time = config.epoch_base_time.as_ref()
-        .map(|stamp| time::OffsetDateTime::parse(stamp, &Rfc3339)
-            .expect("Couldn't parse epoch base time '{stamp}' as RFC 3339"))
-        .unwrap_or(start_time);
+    // Epoch base_time comes from a config argument if given,
+    // otherwise use start_time.
+    let base_time = config.epoch_base_time.unwrap_or(start_time);
+    info!(
+        "epoch base time {}",
+        base_time
+            .format(&Rfc3339)
+            .expect("well-known timestamp format should always succeed")
+    );
 
     // Calculate where we are in the epoch schedule relative to the
     // base time. We may need to start in the middle of the range.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,10 +17,11 @@ const NEXT_EPOCH_TIME: &str = "2023-03-22T21:46:35Z";
 fn test_app() -> crate::Router {
     // arbitrary config
     let config = crate::Config {
+        listen: "127.0.0.1:8081".to_string(),
         epoch_seconds: 1,
         first_epoch: EPOCH,
         last_epoch: EPOCH * 2,
-        listen: "127.0.0.1:8081".to_string(),
+        epoch_basetime: None,
     };
     // server state
     let mut server =

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,7 +21,7 @@ fn test_app() -> crate::Router {
         epoch_seconds: 1,
         first_epoch: EPOCH,
         last_epoch: EPOCH * 2,
-        epoch_basetime: None,
+        epoch_base_time: None,
     };
     // server state
     let mut server =

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,8 @@ use base64::prelude::{Engine as _, BASE64_STANDARD as BASE64};
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use serde_json::{json, Value};
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
+use time::OffsetDateTime;
 use tower::ServiceExt;
 
 const EPOCH: u8 = 12;
@@ -155,6 +157,75 @@ async fn epoch() {
     let request = test_request("/randomness", Some(payload));
     let response = test_app().oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// If --epoch-base-time is set, confirm the server starts
+/// with the correct epoch.
+#[tokio::test]
+async fn epoch_base_time() {
+    let now = OffsetDateTime::now_utc();
+    let delay = Duration::from_secs(5);
+
+    // Config with explicit base time
+    let config = crate::Config {
+        listen: "127.0.0.1:8081".to_string(),
+        epoch_seconds: 1,
+        first_epoch: EPOCH,
+        last_epoch: EPOCH * 2,
+        epoch_base_time: Some(now - delay),
+    };
+    // Verify test parameters are compatible with the
+    // expected_epoch calculation.
+    assert!(EPOCH as u64 + delay.as_secs() < EPOCH as u64 * 2);
+    let expected_epoch = EPOCH + delay.as_secs() as u8;
+    let advance = Duration::from_secs(config.epoch_seconds.into());
+    let expected_time = (now + advance)
+        // Published timestamp is truncated to the second.
+        .replace_millisecond(0)
+        .expect("should be able to truncate to a fixed ms")
+        .format(&time::format_description::well_known::Rfc3339)
+        .expect("well-known timestamp format should always succeed");
+
+    // server state
+    let server =
+        OPRFServer::new(&config).expect("Could not initialize PPOPRF state");
+    let oprf_state = Arc::new(RwLock::new(server));
+    // background task to manage epoch rotation
+    let background_state = oprf_state.clone();
+    tokio::spawn(async move {
+        crate::state::epoch_loop(background_state, &config).await
+    });
+
+    // Wait for `epoch_loop` to update `next_epoch_time` as a proxy
+    // for completing epoch schedule initialization. Use a timeout
+    // to avoid hanging test runs.
+    let pause = Duration::from_millis(10);
+    let mut tries = 0;
+    while oprf_state.read().unwrap().next_epoch_time.is_none() {
+        println!("waiting for {pause:?} for initialization {tries}");
+        assert!(tries < 10, "timeout waiting for epoch_loop initialization");
+        tokio::time::sleep(pause).await;
+        tries += 1;
+    }
+
+    // attach axum routes and middleware
+    let app = crate::app(oprf_state);
+
+    let request = test_request("/info", None);
+    let response = app.oneshot(request).await.unwrap();
+
+    // Info should return the correct epoch, etc.
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    assert!(!body.is_empty());
+    let json: Value = serde_json::from_slice(body.as_ref())
+        .expect("Could not parse response body as json");
+    assert!(json.is_object());
+    println!("{:?}", json);
+    assert_eq!(json["currentEpoch"], json!(expected_epoch));
+    assert!(json["nextEpochTime"].is_string());
+    let next_epoch_time = json["nextEpochTime"].as_str().unwrap();
+    assert_eq!(next_epoch_time, expected_time);
 }
 
 /// Check a randomness response body for validity

--- a/start.sh
+++ b/start.sh
@@ -14,5 +14,5 @@ sleep 1
 
 star-randsrv \
   --epoch-seconds 604800 \
-  --epoch-basetime 2023-05-01T00:00:00Z
+  --epoch-base-time 2023-05-01T00:00:00Z
 echo "[sh] Started star-randsrv."

--- a/start.sh
+++ b/start.sh
@@ -12,5 +12,7 @@ echo "[sh] Started nitriding as reverse proxy."
 
 sleep 1
 
-star-randsrv --epoch-seconds 604800
+star-randsrv \
+  --epoch-seconds 604800 \
+  --epoch-basetime 2023-05-01T00:00:00Z
 echo "[sh] Started star-randsrv."


### PR DESCRIPTION
Align the epoch rotation schedule with a fixed point in absolute time, defaulting to the current time at startup. Skips ahead on the first iteration to the epoch (but not public key!) will be the same for separate instances started with the same base time.

Specify a fixed base time when building a container for more consistent behaviour.

Resolves #54