### PR TITLE
Use nitriding's Prometheus metrics.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Start by building the nitriding proxy daemon.
 FROM public.ecr.aws/docker/library/golang:1.20.4-alpine as go-builder
 
-RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon/cmd@v1.0.2
+RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon/cmd@v1.1.0
 
 # Build the web server application itself.
 # Use the -alpine variant so it will run in a alpine-based container.

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,7 @@ nitriding \
 	-fqdn "star-randsrv.bsg.brave.com" \
 	-appurl "https://github.com/brave/star-randsrv" \
 	-appwebsrv "http://127.0.0.1:8080" \
+	-prometheus-port 9090 \
 	-extport 443 \
 	-intport 8081 &
 echo "[sh] Started nitriding as reverse proxy."


### PR DESCRIPTION
Nitriding in v1.1.0 supports the export of Prometheus metrics.  This commit exposes these metrics on port 9090, which is Prometheus's default port.