### PR TITLE
Update to nitriding v1.2.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Start by building the nitriding proxy daemon.
 FROM public.ecr.aws/docker/library/golang:1.20.5-alpine as go-builder
 
-RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon@v1.2.0
+RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon@v1.2.1
 
 # Build the web server application itself.
 # Use the -alpine variant so it will run in a alpine-based container.


### PR DESCRIPTION
This version exposes the Prometheus Web server over HTTP instead of HTTPS.