### PR TITLE
Update nitriding and set Prometheus namespace.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Start by building the nitriding proxy daemon.
 FROM public.ecr.aws/docker/library/golang:1.20.5-alpine as go-builder
 
-RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon@v1.2.1
+RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon@v1.3.1
 
 # Build the web server application itself.
 # Use the -alpine variant so it will run in a alpine-based container.

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,7 @@ nitriding \
 	-appurl "https://github.com/brave/star-randsrv" \
 	-appwebsrv "http://127.0.0.1:8080" \
 	-prometheus-port 9090 \
+	-prometheus-namespace "starrandsrv" \
 	-extport 443 \
 	-intport 8081 &
 echo "[sh] Started nitriding as reverse proxy."


### PR DESCRIPTION
Note that the namespace must not contain dashes, which is why we are using "starrandsrv" instead of "star-randsrv".