### PR TITLE
Add support for multiple OPRF instances in a single server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "calendar-duration"
+version = "1.0.0"
+source = "git+https://github.com/brave-experiments/calendar-duration?branch=init#76e910c33764c2451a27452904492d202ad4a146"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1251,7 @@ dependencies = [
  "axum",
  "axum-prometheus",
  "base64 0.21.4",
+ "calendar-duration",
  "clap",
  "curve25519-dalek",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,8 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "calendar-duration"
 version = "1.0.0"
-source = "git+https://github.com/brave-experiments/calendar-duration?branch=init#76e910c33764c2451a27452904492d202ad4a146"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76370179d4c93316e4e8482bd113f89621ad8acdbb0e0dacac2d06412eab97f0"
 dependencies = [
  "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 axum = "0.6.20"
 axum-prometheus = "0.4.0"
 base64 = "0.21.4"
+calendar-duration = "1.0.0"
 clap = { version = "4.4.4", features = ["derive"] }
 metrics-exporter-prometheus = "0.12.1"
 ppoprf = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,7 @@ fn app(oprf_state: OPRFState) -> Router {
             "/instances/:instance/info",
             get(handler::specific_instance_info),
         )
+        .route("/instances", get(handler::list_instances))
         // Endpoints for default instance
         .route("/randomness", post(handler::default_instance_randomness))
         .route("/info", get(handler::default_instance_info))

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,15 +1,19 @@
 //! STAR Randomness web service
 //! Epoch and key state and its management
 
-use std::sync::{Arc, RwLock};
-use time::format_description::well_known::Rfc3339;
+use calendar_duration::CalendarDuration;
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::{info, instrument};
 
 use crate::Config;
 use ppoprf::ppoprf;
 
-/// Internal state of the OPRF service
-pub struct OPRFServer {
+/// Internal state of an OPRF instance
+pub struct OPRFInstance {
     /// oprf implementation
     pub server: ppoprf::Server,
     /// currently-valid randomness epoch
@@ -18,18 +22,14 @@ pub struct OPRFServer {
     pub next_epoch_time: Option<String>,
 }
 
-/// Shareable wrapper around the server state
-pub type OPRFState = Arc<RwLock<OPRFServer>>;
-
-impl OPRFServer {
+impl OPRFInstance {
     /// Initialize a new OPRFServer state with the given configuration
     pub fn new(config: &Config) -> Result<Self, ppoprf::PPRFError> {
         // ppoprf wants a vector, so generate one from our range.
-        let epochs: Vec<u8> =
-            (config.first_epoch..=config.last_epoch).collect();
+        let epochs: Vec<u8> = (config.first_epoch..=config.last_epoch).collect();
         let epoch = epochs[0];
         let server = ppoprf::Server::new(epochs)?;
-        Ok(OPRFServer {
+        Ok(OPRFInstance {
             server,
             epoch,
             next_epoch_time: None,
@@ -37,121 +37,193 @@ impl OPRFServer {
     }
 }
 
-/// Advance to the next epoch on a timer
-/// This can be invoked as a background task to handle epoch
-/// advance and key rotation according to the given Config.
-#[instrument(skip_all)]
-pub async fn epoch_loop(state: OPRFState, config: &Config) {
-    let epochs = config.first_epoch..=config.last_epoch;
+/// Container for OPRF instances
+pub struct OPRFServer {
+    /// All OPRF instances, keyed by instance name
+    pub instances: HashMap<String, RwLock<OPRFInstance>>,
+    /// The name of the default instance
+    pub default_instance: String,
+}
 
-    let interval =
-        std::time::Duration::from_secs(config.epoch_seconds.into());
-    info!("rotating epoch every {} seconds", interval.as_secs());
+/// Arc wrapper for OPRFServer
+pub type OPRFState = Arc<OPRFServer>;
 
-    let start_time = time::OffsetDateTime::now_utc();
-    // Epoch base_time comes from a config argument if given,
-    // otherwise use start_time.
-    let base_time = config.epoch_base_time.unwrap_or(start_time);
-    info!(
-        "epoch base time = {}",
-        base_time
-            .format(&Rfc3339)
-            .expect("well-known timestamp format should always succeed")
-    );
+struct StartingEpochInfo {
+    elapsed_epoch_count: usize,
+    next_rotation: OffsetDateTime,
+}
 
-    // Calculate where we are in the epoch schedule relative to the
-    // base time. We may need to start in the middle of the range.
-    assert!(
-        start_time >= base_time,
-        "epoch-base-time should be in the past"
-    );
-    // The time difference will be positive after the assert.
-    // The ratio of two Durations is an f64 (in seconds) which covers
-    // the representable range of `OffsetDateTime`.
-    let elapsed_epochs = ((start_time - base_time) / interval).floor() as u64;
-
-    // The `epochs` range is `u8`, so the length can be no more
-    // than `u8::MAX + 1`, making it safe to truncate the modulo.
-    let offset = elapsed_epochs % epochs.len() as u64;
-    let current_epoch = epochs.start() + offset as u8;
-
-    // Advance to the current epoch if base time indicates we started
-    // in the middle of a sequence.
-    if current_epoch != config.first_epoch {
-        info!(
-            "Puncturing obsolete epochs {}..{} to match base time",
-            config.first_epoch, current_epoch
-        );
-        let mut s = state.write().expect("Failed to lock OPRFState");
-        for epoch in config.first_epoch..current_epoch {
-            s.server
-                .puncture(epoch)
-                .expect("Failed to puncture obsolete epoch");
+impl StartingEpochInfo {
+    fn calculate(base_time: OffsetDateTime, instance_epoch_duration: CalendarDuration) -> Self {
+        let now = time::OffsetDateTime::now_utc();
+        let mut elapsed_epoch_count = 0;
+        let mut next_rotation = base_time + instance_epoch_duration;
+        while next_rotation < now {
+            next_rotation = next_rotation + instance_epoch_duration;
+            elapsed_epoch_count += 1;
         }
-        s.epoch = current_epoch;
-        info!("epoch now {}", s.epoch);
+        Self {
+            elapsed_epoch_count,
+            next_rotation,
+        }
+    }
+}
+
+impl OPRFServer {
+    /// Initialize all OPRF instances with given configuration
+    pub fn new(config: &Config) -> Arc<Self> {
+        let instances = config
+            .instance_names
+            .iter()
+            .map(|instance_name| {
+                // Oblivious function state
+                info!(instance_name, "initializing OPRF state...");
+                let server = OPRFInstance::new(config).expect("Could not initialize PPOPRF state");
+                info!(instance_name, "epoch now {}", server.epoch);
+
+                (instance_name.to_string(), RwLock::new(server))
+            })
+            .collect();
+        Arc::new(OPRFServer {
+            instances,
+            default_instance: config.instance_names.first().cloned().unwrap(),
+        })
     }
 
-    // First rotation happens after whatever time remains for the current epoch.
-    // `Duration` doesn't implement `Mul<u64>` so we must truncate the elapsed
-    // epoch count. Assert that this is valid in case base_time is very large
-    // while inverval is small.
-    assert!(elapsed_epochs < u32::MAX as u64, "cast mustn't overflow");
-    let mut next_rotation =
-        base_time + interval * (elapsed_epochs + 1) as u32;
-
-    loop {
-        // Pre-calculate the next_epoch_time for the InfoResponse hander.
-        // Truncate to the nearest second.
-        let timestamp = next_rotation
-            .replace_millisecond(0)
-            .expect("should be able to truncate to a fixed ms")
-            .format(&Rfc3339)
-            .expect("well-known timestamp format should always succeed");
+    /// Start background tasks to keep OPRF instances up to date
+    pub fn start_background_tasks(self: &Arc<Self>, config: &Config) {
+        for (instance_name, instance_epoch_duration) in config
+            .instance_names
+            .iter()
+            .cloned()
+            .zip(config.epoch_durations.iter().cloned())
         {
-            // Acquire a temporary write lock which should be dropped
-            // before sleeping. The locking should not fail, but if it
-            // does we can't set the field back to None, so panic rather
-            // than report stale information.
-            let mut s = state
-                .write()
-                .expect("should be able to update next_epoch_time");
-            s.next_epoch_time = Some(timestamp);
+            // Spawn a background process to advance the epoch
+            info!(instance_name, "Spawning background epoch rotation task...");
+            let background_state = self.clone();
+            let background_config = config.clone();
+            tokio::spawn(async move {
+                background_state
+                    .epoch_loop(background_config, instance_name, instance_epoch_duration)
+                    .await
+            });
+        }
+    }
+
+    /// Advance to the next epoch on a timer
+    /// This can be invoked as a background task to handle epoch
+    /// advance and key rotation according to the given instance.
+    #[instrument(skip(self, config, instance_epoch_duration))]
+    async fn epoch_loop(
+        self: Arc<Self>,
+        config: Config,
+        instance_name: String,
+        instance_epoch_duration: CalendarDuration,
+    ) {
+        let server = self
+            .instances
+            .get(&instance_name)
+            .expect("OPRFServer should exist for instance name");
+        let epochs = config.first_epoch..=config.last_epoch;
+
+        info!("rotating epoch every {instance_epoch_duration}");
+
+        let start_time = OffsetDateTime::now_utc();
+        // Epoch base_time comes from a config argument if given,
+        // otherwise use start_time.
+        let base_time = config.epoch_base_time.unwrap_or(start_time);
+        info!(
+            "epoch base time = {}",
+            base_time
+                .format(&Rfc3339)
+                .expect("well-known timestamp format should always succeed")
+        );
+
+        // Calculate where we are in the epoch schedule relative to the
+        // base time. We may need to start in the middle of the range.
+        assert!(
+            start_time >= base_time,
+            "epoch-base-time should be in the past"
+        );
+        let StartingEpochInfo {
+            elapsed_epoch_count,
+            mut next_rotation,
+        } = StartingEpochInfo::calculate(base_time, instance_epoch_duration);
+
+        // The `epochs` range is `u8`, so the length can be no more
+        // than `u8::MAX + 1`, making it safe to truncate the modulo.
+        let offset = elapsed_epoch_count % epochs.len();
+        let current_epoch = epochs.start() + offset as u8;
+
+        // Advance to the current epoch if base time indicates we started
+        // in the middle of a sequence.
+        if current_epoch != config.first_epoch {
+            info!(
+                "Puncturing obsolete epochs {}..{} to match base time",
+                config.first_epoch, current_epoch
+            );
+            let mut s = server.write().expect("Failed to lock OPRFServer");
+            for epoch in config.first_epoch..current_epoch {
+                s.server
+                    .puncture(epoch)
+                    .expect("Failed to puncture obsolete epoch");
+            }
+            s.epoch = current_epoch;
+            info!("epoch now {}, next rotation = {next_rotation}", s.epoch);
         }
 
-        // Wait until the current epoch ends.
-        let sleep_duration = next_rotation - time::OffsetDateTime::now_utc();
-        // Negative durations mean we're behind.
-        if sleep_duration.is_positive() {
-            tokio::time::sleep(sleep_duration.unsigned_abs()).await;
+        loop {
+            // Pre-calculate the next_epoch_time for the InfoResponse hander.
+            // Truncate to the nearest second.
+            let timestamp = next_rotation
+                .replace_millisecond(0)
+                .expect("should be able to truncate to a fixed ms")
+                .format(&Rfc3339)
+                .expect("well-known timestamp format should always succeed");
+            {
+                // Acquire a temporary write lock which should be dropped
+                // before sleeping. The locking should not fail, but if it
+                // does we can't set the field back to None, so panic rather
+                // than report stale information.
+                let mut s = server
+                    .write()
+                    .expect("should be able to update next_epoch_time");
+                s.next_epoch_time = Some(timestamp);
+            }
+
+            // Wait until the current epoch ends.
+            let sleep_duration = next_rotation - time::OffsetDateTime::now_utc();
+            // Negative durations mean we're behind.
+            if sleep_duration.is_positive() {
+                tokio::time::sleep(sleep_duration.unsigned_abs()).await;
+            }
+            next_rotation = next_rotation + instance_epoch_duration;
+
+            // Acquire exclusive access to the oprf state.
+            // Panics if this fails, since processing requests with an
+            // expired epoch weakens user privacy.
+            let mut s = server.write().expect("Failed to lock OPRFServer");
+
+            // Puncture the current epoch so it can no longer be used.
+            let old_epoch = s.epoch;
+            s.server
+                .puncture(old_epoch)
+                .expect("Failed to puncture current epoch");
+
+            // Advance to the next epoch, checking for overflow
+            // and out-of-range.
+            let new_epoch = old_epoch.checked_add(1);
+            if new_epoch.filter(|e| epochs.contains(e)).is_some() {
+                // Server is already initialized for this one.
+                s.epoch = new_epoch.unwrap();
+            } else {
+                info!("Epochs exhausted! Rotating OPRF key");
+                // Panics if this fails. Puncture should mean we can't
+                // violate privacy through further evaluations, but we
+                // still want to drop the inner state with its private key.
+                *s = OPRFInstance::new(&config).expect("Could not initialize new PPOPRF server");
+            }
+            info!("epoch now {}, next rotation = {next_rotation}", s.epoch);
         }
-        next_rotation += interval;
-
-        // Acquire exclusive access to the oprf state.
-        // Panics if this fails, since processing requests with an
-        // expired epoch weakens user privacy.
-        let mut s = state.write().expect("Failed to lock OPRFState");
-
-        // Puncture the current epoch so it can no longer be used.
-        let old_epoch = s.epoch;
-        s.server
-            .puncture(old_epoch)
-            .expect("Failed to puncture current epoch");
-
-        // Advance to the next epoch, checking for overflow
-        // and out-of-range.
-        let new_epoch = old_epoch.checked_add(1);
-        if new_epoch.filter(|e| epochs.contains(e)).is_some() {
-            // Server is already initialized for this one.
-            s.epoch = new_epoch.unwrap();
-        } else {
-            info!("Epochs exhausted! Rotating OPRF key");
-            // Panics if this fails. Puncture should mean we can't
-            // violate privacy through further evaluations, but we
-            // still want to drop the inner state with its private key.
-            *s = OPRFServer::new(config)
-                .expect("Could not initialize new PPOPRF state");
-        }
-        info!("epoch now {}", s.epoch);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,36 +2,54 @@
 
 use crate::state::OPRFServer;
 use axum::body::Body;
+use axum::body::Bytes;
 use axum::http::Request;
 use axum::http::StatusCode;
 use base64::prelude::{Engine as _, BASE64_STANDARD as BASE64};
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use rand::rngs::OsRng;
 use serde_json::{json, Value};
-use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use time::OffsetDateTime;
+use tower::Service;
 use tower::ServiceExt;
 
 const EPOCH: u8 = 12;
 const NEXT_EPOCH_TIME: &str = "2023-03-22T21:46:35Z";
 
+struct InstanceConfig {
+    instance_name: String,
+    epoch_duration: String,
+}
+
 /// Create an app instance for testing
-fn test_app() -> crate::Router {
+fn test_app(instance_configs: Option<Vec<InstanceConfig>>) -> crate::Router {
+    let instance_configs = instance_configs.unwrap_or(vec![InstanceConfig {
+        instance_name: "main".to_string(),
+        epoch_duration: "1s".to_string(),
+    }]);
     // arbitrary config
     let config = crate::Config {
         listen: "127.0.0.1:8081".to_string(),
-        epoch_seconds: 1,
+        epoch_durations: instance_configs
+            .iter()
+            .map(|c| c.epoch_duration.as_str().into())
+            .collect(),
         first_epoch: EPOCH,
         last_epoch: EPOCH * 2,
         epoch_base_time: None,
         increase_nofile_limit: false,
         prometheus_listen: None,
+        instance_names: instance_configs
+            .into_iter()
+            .map(|c| c.instance_name)
+            .collect(),
     };
     // server state
-    let mut server = OPRFServer::new(&config).expect("Could not initialize PPOPRF state");
-    server.next_epoch_time = Some(NEXT_EPOCH_TIME.to_owned());
-    let oprf_state = Arc::new(RwLock::new(server));
+    let oprf_state = OPRFServer::new(&config);
+    for instance in oprf_state.instances.values() {
+        instance.write().unwrap().next_epoch_time = Some(NEXT_EPOCH_TIME.to_owned());
+    }
 
     // attach axum routes and middleware
     crate::app(oprf_state)
@@ -58,7 +76,7 @@ fn test_request(uri: &str, payload: Option<String>) -> Request<Body> {
 
 #[tokio::test]
 async fn welcome() {
-    let app = test_app();
+    let app = test_app(None);
 
     let request = test_request("/", None);
     let response = app.oneshot(request).await.unwrap();
@@ -70,21 +88,12 @@ async fn welcome() {
     assert!(!message.is_empty());
 }
 
-#[tokio::test]
-async fn info() {
-    let app = test_app();
-
-    let request = test_request("/info", None);
-    let response = app.oneshot(request).await.unwrap();
-
-    // Info should return the correct epoch, etc.
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+fn validate_info_response_and_return_public_key_b64(status: StatusCode, body: Bytes) -> String {
+    assert_eq!(status, StatusCode::OK);
     assert!(!body.is_empty());
     let json: Value =
         serde_json::from_slice(body.as_ref()).expect("Could not parse response body as json");
     assert!(json.is_object());
-    println!("{:?}", json);
     assert_eq!(json["currentEpoch"], json!(EPOCH));
     assert!(json["nextEpochTime"].is_string());
     let next_epoch_time = json["nextEpochTime"].as_str().unwrap();
@@ -97,11 +106,69 @@ async fn info() {
     let binkey = BASE64.decode(b64key).unwrap();
     let _ = ppoprf::ppoprf::ServerPublicKey::load_from_bincode(&binkey)
         .expect("Could not parse server public key");
+    b64key.to_string()
+}
+
+#[tokio::test]
+async fn info() {
+    let mut app = test_app(Some(vec![
+        InstanceConfig {
+            instance_name: "main".to_string(),
+            epoch_duration: "1s".to_string(),
+        },
+        InstanceConfig {
+            instance_name: "alternate".to_string(),
+            epoch_duration: "1s".to_string(),
+        },
+    ]));
+
+    let response = app.call(test_request("/info", None)).await.unwrap();
+
+    // Info should return the correct epoch, etc.
+    let default_public_key = validate_info_response_and_return_public_key_b64(
+        response.status(),
+        hyper::body::to_bytes(response.into_body()).await.unwrap(),
+    );
+
+    let response = app
+        .call(test_request("/instances/main/info", None))
+        .await
+        .unwrap();
+    let specific_default_public_key = validate_info_response_and_return_public_key_b64(
+        response.status(),
+        hyper::body::to_bytes(response.into_body()).await.unwrap(),
+    );
+    assert_eq!(default_public_key, specific_default_public_key);
+
+    let response = app
+        .call(test_request("/instances/alternate/info", None))
+        .await
+        .unwrap();
+    let alternate_public_key = validate_info_response_and_return_public_key_b64(
+        response.status(),
+        hyper::body::to_bytes(response.into_body()).await.unwrap(),
+    );
+    assert_ne!(default_public_key, alternate_public_key);
+
+    let response = app
+        .call(test_request("/instances/notexisting/info", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
 async fn randomness() {
-    let app = test_app();
+    let mut app = test_app(Some(vec![
+        InstanceConfig {
+            instance_name: "main".to_string(),
+            epoch_duration: "1s".to_string(),
+        },
+        InstanceConfig {
+            instance_name: "alternate".to_string(),
+            epoch_duration: "1s".to_string(),
+        },
+    ]));
 
     // Create a single-point randomness request.
     let point = RistrettoPoint::random(&mut OsRng);
@@ -109,17 +176,46 @@ async fn randomness() {
         BASE64.encode(point.compress().as_bytes())
     ]})
     .to_string();
-    println!("request body {payload:?}");
 
     // Submit to the hander.
-    let request = test_request("/randomness", Some(payload));
-    println!("request {request:?}");
-    let response = app.oneshot(request).await.unwrap();
-    println!("response {response:?}");
+    let request = test_request("/randomness", Some(payload.clone()));
+    let response = app.call(request).await.unwrap();
     // Verify we receive a successful, well-formed response.
     assert_eq!(response.status(), StatusCode::OK);
-    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    verify_randomness_body(body, 1);
+    let default_body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    verify_randomness_body(&default_body, 1);
+
+    let response = app
+        .call(test_request(
+            "/instances/main/randomness",
+            Some(payload.clone()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let specific_default_body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    assert_eq!(default_body, specific_default_body);
+
+    let response = app
+        .call(test_request(
+            "/instances/alternate/randomness",
+            Some(payload.clone()),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let alternate_body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    verify_randomness_body(&alternate_body, 1);
+    assert_ne!(default_body, alternate_body);
+
+    let response = app
+        .call(test_request(
+            "/instances/notexisting/randomness",
+            Some(payload),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -134,10 +230,10 @@ async fn epoch() {
     })
     .to_string();
     let request = test_request("/randomness", Some(payload));
-    let response = test_app().oneshot(request).await.unwrap();
+    let response = test_app(None).oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    verify_randomness_body(body, points.len());
+    verify_randomness_body(&body, points.len());
 
     // Verify earlier epochs are rejected.
     assert!(EPOCH > 0);
@@ -147,7 +243,7 @@ async fn epoch() {
     })
     .to_string();
     let request = test_request("/randomness", Some(payload));
-    let response = test_app().oneshot(request).await.unwrap();
+    let response = test_app(None).oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Verify later epochs are rejected.
@@ -157,7 +253,7 @@ async fn epoch() {
     })
     .to_string();
     let request = test_request("/randomness", Some(payload));
-    let response = test_app().oneshot(request).await.unwrap();
+    let response = test_app(None).oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -171,18 +267,19 @@ async fn epoch_base_time() {
     // Config with explicit base time
     let config = crate::Config {
         listen: "127.0.0.1:8081".to_string(),
-        epoch_seconds: 1,
+        epoch_durations: vec!["1s".into()],
         first_epoch: EPOCH,
         last_epoch: EPOCH * 2,
         epoch_base_time: Some(now - delay),
         increase_nofile_limit: false,
         prometheus_listen: None,
+        instance_names: vec!["main".to_string()],
     };
     // Verify test parameters are compatible with the
     // expected_epoch calculation.
     assert!(EPOCH as u64 + delay.as_secs() < EPOCH as u64 * 2);
     let expected_epoch = EPOCH + delay.as_secs() as u8;
-    let advance = Duration::from_secs(config.epoch_seconds.into());
+    let advance = Duration::from_secs(1);
     let expected_time = (now + advance)
         // Published timestamp is truncated to the second.
         .replace_millisecond(0)
@@ -191,18 +288,17 @@ async fn epoch_base_time() {
         .expect("well-known timestamp format should always succeed");
 
     // server state
-    let server = OPRFServer::new(&config).expect("Could not initialize PPOPRF state");
-    let oprf_state = Arc::new(RwLock::new(server));
+    let oprf_state = OPRFServer::new(&config);
     // background task to manage epoch rotation
-    let background_state = oprf_state.clone();
-    tokio::spawn(async move { crate::state::epoch_loop(background_state, &config).await });
+    oprf_state.start_background_tasks(&config);
 
     // Wait for `epoch_loop` to update `next_epoch_time` as a proxy
     // for completing epoch schedule initialization. Use a timeout
     // to avoid hanging test runs.
     let pause = Duration::from_millis(10);
     let mut tries = 0;
-    while oprf_state.read().unwrap().next_epoch_time.is_none() {
+    let oprf_instance = oprf_state.instances.get("main").unwrap();
+    while oprf_instance.read().unwrap().next_epoch_time.is_none() {
         println!("waiting for {pause:?} for initialization {tries}");
         assert!(tries < 10, "timeout waiting for epoch_loop initialization");
         tokio::time::sleep(pause).await;
@@ -222,7 +318,6 @@ async fn epoch_base_time() {
     let json: Value =
         serde_json::from_slice(body.as_ref()).expect("Could not parse response body as json");
     assert!(json.is_object());
-    println!("{:?}", json);
     assert_eq!(json["currentEpoch"], json!(expected_epoch));
     assert!(json["nextEpochTime"].is_string());
     let next_epoch_time = json["nextEpochTime"].as_str().unwrap();
@@ -230,14 +325,14 @@ async fn epoch_base_time() {
 }
 
 /// Check a randomness response body for validity
-fn verify_randomness_body(body: axum::body::Bytes, expected_points: usize) {
+fn verify_randomness_body(body: &Bytes, expected_points: usize) {
     // Randomness should return a list of points and an epoch.
     assert!(!body.is_empty());
     let json: Value =
         serde_json::from_slice(body.as_ref()).expect("Response body should parse as json");
     // Top-level value should be an object.
     assert!(json.is_object());
-    // Epoch should match test_app.
+    // Epoch should match test_app.None
     let epoch = json["epoch"].as_u64().unwrap();
     assert_eq!(epoch, EPOCH as u64);
     // Points array should have the expected number of elements.
@@ -265,13 +360,13 @@ fn make_points(count: usize) -> Vec<String> {
 
 /// Verify randomness response to a batch of points
 async fn verify_batch(points: &[String]) {
-    let app = test_app();
+    let app = test_app(None);
     let payload = json!({ "points": points }).to_string();
     let request = test_request("/randomness", Some(payload));
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
-    verify_randomness_body(body, points.len());
+    verify_randomness_body(&body, points.len());
 }
 
 #[tokio::test]
@@ -297,6 +392,6 @@ async fn max_points() {
     let points = make_points(crate::MAX_POINTS + 1);
     let payload = json!({ "points": points }).to_string();
     let request = test_request("/randomness", Some(payload));
-    let response = test_app().oneshot(request).await.unwrap();
+    let response = test_app(None).oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,17 @@
+use std::collections::HashSet;
+
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+/// Parse a timestamp given as a config option
+pub fn parse_timestamp(stamp: &str) -> Result<OffsetDateTime, &'static str> {
+    OffsetDateTime::parse(stamp, &Rfc3339).map_err(|_| "Try something like '2023-05-15T04:30:00Z'.")
+}
+
+/// Asserts that all instance names are unique
+pub fn assert_unique_names(instance_names: &[String]) {
+    let mut name_set = HashSet::new();
+    assert!(
+        instance_names.iter().all(|n| name_set.insert(n)),
+        "all instance names must be unique"
+    );
+}

--- a/start.sh
+++ b/start.sh
@@ -15,7 +15,12 @@ echo "[sh] Started nitriding as reverse proxy."
 sleep 1
 
 star-randsrv \
-  --epoch-seconds 604800 \
-  --epoch-base-time 2023-05-01T00:00:00Z \
-  --increase-nofile-limit
+	--instance-name weekly \
+	--epoch-duration "1w" \
+	--instance-name daily \
+	--epoch-duration "1d" \
+	--instance-name monthly \
+	--epoch-duration "1mon" \
+	--epoch-base-time 2023-05-01T00:00:00Z \
+	--increase-nofile-limit
 echo "[sh] Started star-randsrv."

--- a/start.sh
+++ b/start.sh
@@ -1,26 +1,26 @@
 #!/bin/sh
 
 nitriding \
-	-fqdn "star-randsrv.bsg.brave.com" \
-	-appurl "https://github.com/brave/star-randsrv" \
-	-appwebsrv "http://127.0.0.1:8080" \
-	-prometheus-port 9090 \
-	-vsock-ext \
-	-disable-keep-alives \
-	-prometheus-namespace "nitriding" \
-	-extport 443 \
-	-intport 8081 &
+  -fqdn "star-randsrv.bsg.brave.com" \
+  -appurl "https://github.com/brave/star-randsrv" \
+  -appwebsrv "http://127.0.0.1:8080" \
+  -prometheus-port 9090 \
+  -vsock-ext \
+  -disable-keep-alives \
+  -prometheus-namespace "nitriding" \
+  -extport 443 \
+  -intport 8081 &
 echo "[sh] Started nitriding as reverse proxy."
 
 sleep 1
 
 star-randsrv \
-	--instance-name weekly \
-	--epoch-duration "1w" \
-	--instance-name daily \
-	--epoch-duration "1d" \
-	--instance-name monthly \
-	--epoch-duration "1mon" \
-	--epoch-base-time 2023-05-01T00:00:00Z \
-	--increase-nofile-limit
+  --instance-name typical \
+  --epoch-duration "1w" \
+  --instance-name express \
+  --epoch-duration "1d" \
+  --instance-name slow \
+  --epoch-duration "1mon" \
+  --epoch-base-time 2023-05-01T00:00:00Z \
+  --increase-nofile-limit
 echo "[sh] Started star-randsrv."


### PR DESCRIPTION
This will allow us to have separate OPRF instances for each P3A cadence: monthly, weekly and daily.