### PR TITLE
Remove direct dependency on metrics_exporter_prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,6 @@ dependencies = [
  "calendar-duration",
  "clap",
  "curve25519-dalek",
- "metrics-exporter-prometheus",
  "ppoprf",
  "rand",
  "rlimit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ axum-prometheus = "0.5.0"
 base64 = "0.21.5"
 calendar-duration = "1.0.0"
 clap = { version = "4.4.12", features = ["derive"] }
-metrics-exporter-prometheus = "0.12.2"
 ppoprf = "0.3.1"
 rlimit = "0.10"
 serde = "1.0.193"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@
 
 use axum::{routing::get, routing::post, Router};
 use axum_prometheus::PrometheusMetricLayer;
+use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
 use calendar_duration::CalendarDuration;
 use clap::Parser;
-use metrics_exporter_prometheus::PrometheusHandle;
 use rlimit::Resource;
 use state::{OPRFServer, OPRFState};
 use tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
We referenced this just to import the `PrometheusHandle` type returned by `axum_prometheus::PrometheusMetricLayer::pair()`. That crate re-exports its version of that same crate, so we can refer to it by that path and not need to keep them in sync.

Thanks to Péter Leéh for the suggestion in
https://github.com/Ptrskay3/axum-prometheus/issues/38