### PR TITLE
Use the non-slim rust base image for the deployment build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ FROM public.ecr.aws/docker/library/golang:1.21.6-bookworm as go-builder
 RUN CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" -buildvcs=false github.com/brave/nitriding-daemon@v1.4.2
 
 # Build the web server application itself.
-FROM public.ecr.aws/docker/library/rust:1.75.0-slim-bookworm as rust-builder
-
-RUN apt update && apt install -y build-essential
+FROM public.ecr.aws/docker/library/rust:1.75.0-bookworm as rust-builder
 
 WORKDIR /src/
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
The non-slim container image includes both the `libssl-dev` and `pkg-config` packages, which are required by the `openssl-sys` crate dependency added by `axum-prometheus` 0.6, but not included in the `build-essential` package we were installing for other dependencies.

The image is almost twice the size but includes all of build-esential as well, so it may well run faster.

Probably we can go back to slim if the `hypertls` dep can be dropped from the prometheus stack's push feature, which we're not using.

Resolves #277