### PR TITLE
Update base64 to v0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,7 +1320,7 @@ version = "0.2.0"
 dependencies = [
  "axum",
  "axum-prometheus",
- "base64 0.21.7",
+ "base64 0.22.1",
  "calendar-duration",
  "clap",
  "curve25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 axum = "0.7.5"
 axum-prometheus = "0.6.1"
-base64 = "0.21.7"
+base64 = "0.22.1"
 calendar-duration = "1.0.0"
 clap = { version = "4.5.4", features = ["derive"] }
 ppoprf = "0.3.1"


### PR DESCRIPTION
Nothing essential here, just recording review and keeping dependencies up to date. Normally we allow the renovate bot to do these, but it got confused.

Manual re-spin of #328.